### PR TITLE
Stringify event.data in handlers

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,6 +1,14 @@
+import stringify from 'json-stringify-safe';
+
+function dataToString(data) {
+    return data && typeof data === 'object'
+            ? stringify(data)
+            : String(data);
+}
+
 const handlers = {
     ['log']: event => ({
-        msg: `[${event.tags}] ${event.data}`,
+        msg: `[${event.tags}] ${dataToString(event.data)}`,
     }),
 
     ['error']: event => ({
@@ -22,7 +30,7 @@ const handlers = {
     },
 
     ['request']: event => ({
-        msg: `[${event.tags}] ${event.method.toUpperCase()} ${event.path} ${event.data}`,
+        msg: `[${event.tags}] ${event.method.toUpperCase()} ${event.path} ${dataToString(event.data)}`,
     }),
 };
 

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -1,9 +1,16 @@
 import stringify from 'json-stringify-safe';
 
 function dataToString(data) {
-    return data && typeof data === 'object'
-            ? stringify(data)
-            : String(data);
+    const dataType = typeof data;
+    let result;
+    if (data && dataType === 'object') {
+        result = stringify(data);
+    } else if (dataType === 'undefined') {
+        result = '';
+    } else {
+        result = String(data);
+    }
+    return result;
 }
 
 const handlers = {

--- a/package.json
+++ b/package.json
@@ -37,9 +37,10 @@
   },
   "homepage": "https://github.com/alexandrebodin/hapi-good-winston",
   "dependencies": {
+    "good": ">= 7.x",
     "hapi": ">=10.x",
-    "winston": ">=2.x",
-    "good": ">= 7.x"
+    "json-stringify-safe": "^5.0.1",
+    "winston": ">=2.x"
   },
   "peerDependencies": {
     "hapi": ">=10.x",

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -6,6 +6,14 @@ const log = {
     pid: 64291,
 };
 
+const logObjData = {
+    event: 'log',
+    timestamp: 1458264810957,
+    tags: ['log', 'info'],
+    data: { param: [1, 'some data', false] },
+    pid: 64291,
+};
+
 const ops = {
     event: 'ops',
     timestamp: 1458264810957,
@@ -67,6 +75,17 @@ const request = {
     path: '/',
 };
 
+const requestObjData = {
+    event: 'request',
+    timestamp: 1458264810957,
+    tags: ['user', 'info'],
+    data: [{route: '/call', query: 'a=1&b=2'}, 'payload'],
+    pid: 64291,
+    id: '1419005623332:new-host.local:48767:i3vrb3z7:10000',
+    method: 'post',
+    path: '/api/v1/call',
+};
+
 const error = {
     event: 'error',
     timestamp: 1458264810957,
@@ -82,8 +101,10 @@ const error = {
 
 export default {
     request,
+    requestObjData,
     error,
     response,
     ops,
     log,
+    logObjData,
 };

--- a/test/index.js
+++ b/test/index.js
@@ -89,6 +89,16 @@ test('testing log handler', t => {
     t.deepEqual(handlers[fixtures.log.event](fixtures.log), expected);
 });
 
+test('testing log handler with object data', t => {
+    t.plan(1);
+
+    const expected = {
+        msg: `[log,info] {"param":[1,"some data",false]}`,
+    };
+
+    t.deepEqual(handlers[fixtures.logObjData.event](fixtures.logObjData), expected);
+});
+
 test('testing error handler', t => {
     t.plan(1);
 
@@ -111,6 +121,16 @@ test('testing request handler', t => {
     };
 
     t.deepEqual(handlers[fixtures.request.event](fixtures.request), expected);
+});
+
+test('testing request handler with object data', t => {
+    t.plan(1);
+
+    const expected = {
+        msg: `[user,info] POST /api/v1/call [{"route":"/call","query":"a=1&b=2"},"payload"]`,
+    };
+
+    t.deepEqual(handlers[fixtures.requestObjData.event](fixtures.requestObjData), expected);
 });
 
 test('testing response handler', t => {


### PR DESCRIPTION
I have added stringifying of event.data objects (like in [good-console](https://github.com/hapijs/good-console/blob/master/lib/index.js) and [SafeJson from good-squeeze](https://github.com/hapijs/good-squeeze/blob/master/lib/safe-json.js)). Now data objects are written into a log more appropriate (instead of `[object Object]`).