### PR TITLE
Require @hapi/hapi and @hapi/good

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ dist
 # Optional REPL history
 .node_repl_history
 
-
 # Mac file
 .DS_Store
+
+# npm lock file
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A good reporter to send and log events with winston
 
 ## Disclaimer
 
+As hapi recently changed npm namespace, Hapi-good-winston `3` only support good >= 8 and hapi >= 18
+
+-   Use `2.*` for version prior to hapi v18
+
 Hapi-good-winston `2` only support good >= 8 and hapi >= 17
 
 -   Use `1.*` for version prior to hapi v17

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-good-winston",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A hapi good reporter to log events with winston",
   "main": "./dist/index.js",
   "scripts": {
@@ -37,14 +37,14 @@
   },
   "homepage": "https://github.com/alexandrebodin/hapi-good-winston",
   "dependencies": {
-    "good": ">=8.x || 8.0.0-rc1",
-    "hapi": ">=17.x",
+    "@hapi/good": "^8.0",
+    "@hapi/hapi": "^18.0",
     "json-stringify-safe": "^5.0.1",
     "winston": "2.x || 3.x"
   },
   "peerDependencies": {
-    "good": ">=8.x || 8.0.0-rc1",
-    "hapi": ">=17.x",
+    "@hapi/good": "^8.0",
+    "@hapi/hapi": "^18.0",
     "winston": "2.x || 3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
As hapi recently changed its name on npm to @hapi/hapi, we need an upgrade not to be left behind by deprecation.

After this is merged, master should be tagged to 3.0.0